### PR TITLE
File dowload fix on Chromium browsers

### DIFF
--- a/examples/file_download/.gitignore
+++ b/examples/file_download/.gitignore
@@ -1,0 +1,15 @@
+.dub
+docs.json
+__dummy.html
+docs/
+/file_download
+file_download.so
+file_download.dylib
+file_download.dll
+file_download.a
+file_download.lib
+file_download-test-*
+*.exe
+*.o
+*.obj
+*.lst

--- a/examples/file_download/dub.sdl
+++ b/examples/file_download/dub.sdl
@@ -1,0 +1,3 @@
+name "file_download"
+description "Simple demo for file download"
+dependency "lighttp" path="../.."

--- a/examples/file_download/source/app.d
+++ b/examples/file_download/source/app.d
@@ -1,0 +1,23 @@
+import std.file;
+import std.stdio;
+
+import lighttp;
+
+void main(string[] args) {
+	auto server = new Server();
+	
+	server.host("0.0.0.0");
+	server.host("::");
+	
+	server.router.add(new Router());
+	server.run();
+}
+
+class Router {
+	@Get("") getDownload(ServerRequest req, ServerResponse res) {
+		res.headers["Content-Type"] = "text/html";
+		res.headers["Content-Disposition"] = "attachment; filename=\"test.html\"";
+
+		res.body = "<HTML>Save me!</HTML>";
+	}
+}

--- a/src/lighttp/util.d
+++ b/src/lighttp/util.d
@@ -21,7 +21,7 @@ struct Status {
 	/**
 	 * HTTP response status code.
 	 */
-	uint code;
+	uint code = 200;
 	
 	/**
 	 * Additional short description of the status code.


### PR DESCRIPTION
Hi. 
Regarding this #3 issue. 

I found that, request status code is always 0 unless it's specified by user in the route handlers.
To fix the download issue on Chrome and other Chromium browsers there are two ways: 

either explicitly specify the status code in the handler like in the following example:

```d
@Get("download") getDownload(ServerRequest req, ServerResponse res) {
	res.headers["Content-Type"] = "application/json";
	res.headers["Content-Disposition"] = "attachment; filename=\"test.json\";";
	res.body = "{}";
        res.status = StatusCodes.ok; // this would do the trick
}
```
or provide a default value for status in Status struct from util.d source file:

```d 
uint code = 200;
```
#
PS:
You can test the example I included in this pull request.